### PR TITLE
fixed the bad path, missing the /p/

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ The list is available at `/list`
 
 npm install https://github.com/esripdx/ep_padlist/tarball/master
 
+One crucial issue is to ensure that the URL path to individual pads is correct. By default etherpad-lite has a URL template like http://localhost:9001/p/[padname] - depending on how you configure your webserver that proxies the node server, you may eliminate the /p/ to make the pads' URLs more "friendly", e.g. http(s)://[sitename]/[padname] - in that case, you will need to remove the /p/ from templates/pad.html, or otherwise alter it to suit your needs.
+
 ### License
 
 Copyright 2013 Esri, Inc

--- a/templates/pads.html
+++ b/templates/pads.html
@@ -14,7 +14,7 @@
   </div>
   <ul>
     <% pads.forEach(function(pad){ %>
-      <li><a href="/<%= pad.toString() %>"><%= pad.toString() %></a></li>
+      <li><a href="/p/<%= pad.toString() %>"><%= pad.toString() %></a></li>
     <% }) %>
   </ul>
 


### PR DESCRIPTION
Not sure if the /p/ in the etherpad-lite pad path is hard coded or what, but the padlist plugin has always failed to work for me because it is missing. Have patched the pads.html template to include the /p/ in the URL path and it now works for me. If the "/p/" part of the path is a configurable option, then of course replacing this with a token would be better... I'm not sure if it is, however.
