### PR TITLE
path to pads according to ep_lite

### DIFF
--- a/templates/pads.html
+++ b/templates/pads.html
@@ -14,7 +14,7 @@
   </div>
   <ul>
     <% pads.forEach(function(pad){ %>
-      <li><a href="/<%= pad.toString() %>"><%= pad.toString() %></a></li>
+      <li><a href="/p/<%= pad.toString() %>"><%= pad.toString() %></a></li>
     <% }) %>
   </ul>
 


### PR DESCRIPTION
Hi, if I am not mistaken the standard route to a pad in eplite is /p/&lt;padname&gt;, the route the links in the pads.html-template were pointing to though was /&lt;padname&gt;. I changed that and now it works with the eplite instance I am using.
